### PR TITLE
Refactor routing for scaled zero, remove healthcheck

### DIFF
--- a/ci/k8s/app-a/virtualservice.yaml
+++ b/ci/k8s/app-a/virtualservice.yaml
@@ -15,8 +15,8 @@ spec:
           X-Gozero-Target-Port: "3000"
           X-Gozero-Target-Host: "app.app-a.svc.cluster.local"
           X-Gozero-Target-Scheme: "http"
-          X-Gozero-Target-Health-Path: "/pass"
-          X-Gozero-Target-Health-Retries: "20"
+          X-Gozero-Target-Retries: "20"
+          X-Gozero-Target-Backoff: "100ms"
     route:
     # - destination:
     #     host: app.app-a.svc.cluster.local

--- a/ci/k8s/app-a/virtualservice.yaml
+++ b/ci/k8s/app-a/virtualservice.yaml
@@ -15,7 +15,7 @@ spec:
           X-Gozero-Target-Port: "3000"
           X-Gozero-Target-Host: "app.app-a.svc.cluster.local"
           X-Gozero-Target-Scheme: "http"
-          X-Gozero-Target-Retries: "20"
+          X-Gozero-Target-Retries: "10"
           X-Gozero-Target-Backoff: "100ms"
     route:
     # - destination:
@@ -26,3 +26,6 @@ spec:
         host: gozero.gozero.svc.cluster.local
         port:
           number: 8443
+    retries:
+      attempts: 1
+      perTryTimeout: 300s

--- a/ci/k8s/gozero/manifests.yaml
+++ b/ci/k8s/gozero/manifests.yaml
@@ -23,12 +23,12 @@ spec:
     spec:
       containers:
       - name: gozero
-        image: rminz/gozero:0.1.0
+        image: rminz/gozero:0.1.4
         env:
         - name: REDIS_ADDR
           value: redis.gozero.svc.cluster.local
         - name: LOG_LEVEL
-          value: info
+          value: debug
         resources:
           limits:
             memory: "128Mi"

--- a/ci/k8s/gozero/manifests.yaml
+++ b/ci/k8s/gozero/manifests.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: gozero
-        image: rminz/gozero:0.0.10
+        image: rminz/gozero:0.1.0
         env:
         - name: REDIS_ADDR
           value: redis.gozero.svc.cluster.local

--- a/ci/k8s/redis/manifests.yaml
+++ b/ci/k8s/redis/manifests.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gozero
+  labels:
+    istio-injection: enabled
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/araminian/gozero
 go 1.23.2
 
 require (
+	github.com/eapache/go-resiliency v1.7.0
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.9.0
@@ -18,7 +19,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/eapache/go-resiliency v1.7.0 h1:n3NRTnBn5N0Cbi/IeOHuQn9s2UwVUH7Ga0ZWcP+9JTA=
+github.com/eapache/go-resiliency v1.7.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
 github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
@@ -24,8 +26,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=

--- a/internal/proxy/http-proxy.go
+++ b/internal/proxy/http-proxy.go
@@ -162,7 +162,7 @@ func (rr *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	})
 
 	if respErr != nil {
-		msg := fmt.Sprintf("all retry attempts failed for service '%s' -> '%s': %v", originalHost, targetHost, respErr)
+		msg := fmt.Sprintf("all retry attempts failed for service '%s' -> '%s': %v. Service failed to scaled up or not passing probes", originalHost, targetHost, respErr)
 		config.Log.Errorf(msg)
 		return resp, errors.New(msg)
 	}

--- a/internal/proxy/http-proxy.go
+++ b/internal/proxy/http-proxy.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -36,6 +37,7 @@ const (
 	defaultIdleTimeout           = 120 * time.Second
 	defaultTLSHandshakeTimeout   = 10 * time.Second
 	defaultResponseHeaderTimeout = 30 * time.Second
+	defaultDialTimeout           = 300 * time.Second
 )
 
 type httpReverseProxyConfig struct {
@@ -215,6 +217,7 @@ func (p *HTTPReverseProxy) Start(ctx context.Context) error {
 			IdleConnTimeout:       defaultIdleTimeout,
 			TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
 			ResponseHeaderTimeout: defaultResponseHeaderTimeout,
+			DialContext:           (&net.Dialer{Timeout: defaultDialTimeout}).DialContext,
 		},
 	}
 


### PR DESCRIPTION
Here i adjust the routing. 

## Old

In old implementation , before sending the actual request to the backend. `Proxy` sends requests to the `Backend Health endpoint` . If it gets error in response , then it retries. otherwise `proxy` sends the actual request to the backend.

This implementation was not optimal, because:

`Proxy` shouldn't responsible for `Health Check` and retries , when we have better place for it which is `RoundTripper`. And we shouldn't check if the Pod is healthy and do retries before each request. It's not efficient. We need to give user fast feedback. If the service is broken and request should be failed , why we need to do retry.

## New Changes

Here i remove the `Health check` mechanism. `RoundTripper` is checking if the response is `503` and  `body` contains `no healthy upstream` which means there is no available/healthy `Pod` and `proxy` needs to wait and retry.

`istio sidecar` sends a response with status-code `503` and with body of `no healthy upstream`, when the service doesn't have any endpoint.

The request flow is : `Director` -> `RoundTripper`  -> `ModifyResponse`

**NOTE** : if `deployment` has a `readiness probe` and `readiness probe` fails , then there is no endpoint on `service` , so we will get the `503` and `no healthy upstream`. So `proxy` will do retries. ATM i don't know any mechanism to distinguish between this scenario and `scaled zero deployment` , however we can add `K8S` integrations to the proxy to check deployment's replicas, if there is `no replica && 503 && no health upstream` then do retry , otherwise no retry. I'm not sure if we need this. or can tolerate this scenario.

 I set `TCP Timeout to 5min` which means that `proxy` waits `5min` to establish `TCP` connection , maybe it's enough and we don't need to check `Health` or do `retries` mechanism. **UPDATE**: No because our `gozero proxy` has a sidecar and it first connects to the sidecar so this `Timeout` would be useless! But it can be useful when the `gozero proxy` will be deployed without `sidecar`.
 