### PR TITLE
Handle GRPC and HTTP2

### DIFF
--- a/ci/k8s/app-a/virtualservice.yaml
+++ b/ci/k8s/app-a/virtualservice.yaml
@@ -29,3 +29,15 @@ spec:
     retries:
       attempts: 1
       perTryTimeout: 300s
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: app
+  namespace: app-a
+spec:
+  host: app.app-a.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        useClientProtocol: true

--- a/ci/k8s/gozero/manifests.yaml
+++ b/ci/k8s/gozero/manifests.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: gozero
-        image: rminz/gozero:0.1.4
+        image: rminz/gozero:0.2.4
         env:
         - name: REDIS_ADDR
           value: redis.gozero.svc.cluster.local
@@ -52,3 +52,32 @@ spec:
   - port: 9090
     name: metrics
     targetPort: 9090
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: gozero
+  namespace: gozero
+spec:
+  host: gozero.gozero.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        h2UpgradePolicy: UPGRADE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: gozero
+  namespace: gozero
+spec:
+  hosts:
+  - gozero.gozero.svc.cluster.local
+  exportTo:
+  - "*"
+  http:
+  - route:
+    - destination:
+        host: gozero.gozero.svc.cluster.local
+        port:
+          number: 8443

--- a/ci/k8s/grpc-server/manifests.yaml
+++ b/ci/k8s/grpc-server/manifests.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grpc-server
+  labels:
+    istio-injection: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-server
+  namespace: grpc-server
+spec:
+  selector:
+    matchLabels:
+      app: grpc-server
+  template:
+    metadata:
+      labels:
+        app: grpc-server
+    spec:
+      containers:
+      - name: grpc-server
+        image: rminz/grpc-server:v4
+        args:
+        - "0.0.0.0:5557"
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 5557
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-server
+  namespace: grpc-server
+spec:
+  selector:
+    app: grpc-server
+  ports:
+  - port: 5557
+    targetPort: 5557
+    name: grpc
+    protocol: TCP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: grpc-server
+  namespace: grpc-server
+spec:
+  hosts:
+  - grpc-server-grpc-server.k8s.orb.local
+  gateways:
+  - istio-system/ingress
+  http:
+  - headers:
+      request:
+        add:
+          X-Gozero-Target-Port: "5557"
+          X-Gozero-Target-Host: "grpc-server.grpc-server.svc.cluster.local"
+          X-Gozero-Target-Scheme: "http"
+          X-Gozero-Target-Retries: "10"
+          X-Gozero-Target-Backoff: "100ms"
+    route:
+    # - destination:
+    #     host: app.app-a.svc.cluster.local
+    #     port:
+    #       number: 3000
+    - destination:
+        host: gozero.gozero.svc.cluster.local
+        port:
+          number: 8443
+    retries:
+      attempts: 1
+      perTryTimeout: 300s

--- a/ci/k8s/istio/gateway.yaml
+++ b/ci/k8s/istio/gateway.yaml
@@ -13,3 +13,9 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
+  - port:
+      number: 6565
+      name: grpc
+      protocol: GRPC
+    hosts:
+    - "*"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ require (
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.17.0
 )
+
+require golang.org/x/text v0.13.0 // indirect
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,11 +44,15 @@ github.com/valyala/fasthttp v1.51.0 h1:8b30A5JlZ6C7AS81RsWjYMQmrZG6feChmgAolCl1S
 github.com/valyala/fasthttp v1.51.0/go.mod h1:oI2XroL+lI7vdXyYoQk03bXBThfFl2cVdIA3Xl7cH8g=
 github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test.sh
+++ b/test.sh
@@ -3,3 +3,5 @@ curl -k --proto-default https -H "Host: www.trivago.com" localhost:8443
 curl -k --proto-default https -H "Host: www.booking.com" localhost:8443
 
 openssl req -x509 -newkey rsa:2048 -keyout server.key -out server.crt -days 365 -nodes
+
+curl -X GET   -H "X-Gozero-Target-Port: 3000"   -H "X-Gozero-Target-Host: app.app-a.svc.cluster.local"   -H "X-Gozero-Target-Scheme: http"   -H "X-Gozero-Target-Retries: 10"   -H "X-Gozero-Target-Backoff: 100ms" gozero.gozero.svc.cluster.local:8443/pass -vvv


### PR DESCRIPTION
Here i implement `HTTP2` support. As `GRPC` is on top of the `HTTP2` , if `proxy` can handle `HTTP2` , it can also handle `GRPC` traffic.

There was a challenge the `HTTP2` official Go package can only work with `TLS` , but here i'm using a different implementation that can support `HTTP2 Cleartext (h2c)`, in order to do that:

- Server should handle `HTTP2`
- We need two different `Transports` , `HTTP1` and `HTTP2` to handle communications on those protocols
- Proxy detects requested protocol and select `Transport`
- I did a test with this [code](https://github.com/araminian/grpcch4) which has all 4 types of the `GRPC` communication , and `proxy` handles them without any issue.
![image](https://github.com/user-attachments/assets/b36fc5db-6d52-4c62-8f1b-6a616202dff1)
   